### PR TITLE
Add ResponsesDashboardComplete table model

### DIFF
--- a/nmbroker/dbaccess/models.cpp
+++ b/nmbroker/dbaccess/models.cpp
@@ -34,7 +34,6 @@ std::unique_ptr<viewPatentMattersModel> gViewPatentMattersModel;
 std::unique_ptr<viewPatentTaskTypesModel> gViewPatentTaskTypesModel;
 std::unique_ptr<viewPeopleModel> gViewPeopleModel;
 std::unique_ptr<viewResponsesModel> gViewResponsesModel;
-std::unique_ptr<viewResponsesIncompleteModel> gViewResponsesIncompleteModel;
 std::unique_ptr<viewResponseTaskTypesModel> gViewResponseTaskTypesModel;
 std::unique_ptr<viewTasksModel> gViewTasksModel;
 std::unique_ptr<viewTaskClassModel> gViewTaskClassModel;
@@ -44,5 +43,6 @@ std::unique_ptr<viewTrademarkMattersModel> gViewTrademarkMattersModel;
 std::unique_ptr<viewUpcomingAppointmentsModel> gViewUpcomingAppointmentsModel;
 std::unique_ptr<viewTrademarkTaskTypesModel> gViewTrademarkTaskTypesModel;
 std::unique_ptr<viewWorkAttorneysModel> gViewWorkAttorneysModel;
+std::unique_ptr<ResponsesDashboardComplete> gResponsesDashboardComplete;
 
 } //namespace Nutmeg

--- a/nmbroker/dbaccess/models.h
+++ b/nmbroker/dbaccess/models.h
@@ -35,7 +35,6 @@
 #include "viewpatenttasktypesmodel.h"
 #include "viewpeoplemodel.h"
 #include "viewresponsesmodel.h"
-#include "viewresponsesincompletemodel.h"
 #include "viewresponsetasktypesmodel.h"
 #include "viewtasksmodel.h"
 #include "viewtaskclassmodel.h"
@@ -43,6 +42,7 @@
 #include "viewtrademarkfilingtypesmodel.h"
 #include "viewtrademarktasktypesmodel.h"
 #include "viewworkattorneysmodel.h"
+#include "responsesdashboardcomplete.h"
 
 namespace Nutmeg{
 extern std::unique_ptr<appointmentTypeModel> gAppointmentTypeModel;
@@ -75,7 +75,6 @@ extern std::unique_ptr<viewPatentFilingTypesModel> gViewPatentFilingTypesModel;
 extern std::unique_ptr<viewPatentTaskTypesModel> gViewPatentTaskTypesModel;
 extern std::unique_ptr<viewPeopleModel> gViewPeopleModel;
 extern std::unique_ptr<viewResponsesModel> gViewResponsesModel;
-extern std::unique_ptr<viewResponsesIncompleteModel> gViewResponsesIncompleteModel;
 extern std::unique_ptr<viewResponseTaskTypesModel> gViewResponseTaskTypesModel;
 extern std::unique_ptr<viewTaskClassModel> gViewTaskClassModel;
 extern std::unique_ptr<viewTaskTypesModel> gViewTaskTypesModel;
@@ -85,6 +84,7 @@ extern std::unique_ptr<viewTasksModel> gViewTasksModel;
 extern std::unique_ptr<viewTrademarkTaskTypesModel> gViewTrademarkTaskTypesModel;
 extern std::unique_ptr<viewUpcomingAppointmentsModel> gViewUpcomingAppointmentsModel;
 extern std::unique_ptr<viewWorkAttorneysModel> gViewWorkAttorneysModel;
+extern std::unique_ptr<ResponsesDashboardComplete> gResponsesDashboardComplete;
 
 } //namespace Nutmeg
 

--- a/nmbroker/dbaccess/responsesdashboardcomplete.cpp
+++ b/nmbroker/dbaccess/responsesdashboardcomplete.cpp
@@ -1,0 +1,22 @@
+#include "responsesdashboardcomplete.h"
+#include "models.h"
+#include "record.h"
+
+namespace Nutmeg {
+
+ResponsesDashboardComplete::ResponsesDashboardComplete(QObject *parent)
+    : Nutmeg::TableModel{parent}
+{
+    setTable("responsesDashboardComplete");
+    if (select())
+    {
+        IndexLocations();
+    }
+}
+
+QSqlRecord ResponsesDashboardComplete::record(Key primaryKey)
+{
+        return Nutmeg::record<ResponsesDashboardComplete>(primaryKey, gResponsesDashboardComplete);
+}
+
+} // namespace Nutmeg

--- a/nmbroker/dbaccess/responsesdashboardcomplete.h
+++ b/nmbroker/dbaccess/responsesdashboardcomplete.h
@@ -1,0 +1,21 @@
+#ifndef NUTMEG_RESPONSESDASHBOARDCOMPLETE_H
+#define NUTMEG_RESPONSESDASHBOARDCOMPLETE_H
+
+#include <QObject>
+#include <QSqlRecord>
+#include "tablemodel.h"
+
+namespace Nutmeg {
+
+class ResponsesDashboardComplete : public Nutmeg::TableModel
+{
+    Q_OBJECT
+public:
+    explicit ResponsesDashboardComplete(QObject *parent = nullptr);
+
+    static QSqlRecord record(Key primaryKey);
+};
+
+} // namespace Nutmeg
+
+#endif // NUTMEG_RESPONSESDASHBOARDCOMPLETE_H

--- a/nmbroker/objects/filingsdashboardentry.cpp
+++ b/nmbroker/objects/filingsdashboardentry.cpp
@@ -1,69 +1,154 @@
 #include "filingsdashboardentry.h"
+#include "dbaccess/nutdb.h"
 
 namespace Nutmeg{
 
+filingsDashboardEntry::filingsDashboardEntry(const QSqlRecord &record)
+{
+    m_TaskId = record.value("TaskId").toUInt();
+    m_TaskClassName = record.value("TaskClassName").toString();
+    m_AttorneyDocketNumber = record.value("AttorneyDocketNumber").toString();
+    m_TaskName = record.value("TaskName").toString();
+    m_Title = record.value("Title").toString();
+    m_TriggerDate = record.value("TriggerDate").toDate();
+    m_NextDeadline = record.value("NextDeadline").toDate();
+    m_SoftDeadline = record.value("SoftDeadline").toDate();
+    m_HardDeadline = record.value("HardDeadline").toDate();
+    m_ClientEntityId = record.value("ClientEntityId").toUInt();
+    m_ClientEntityName = record.value("ClientEntityName").toString();
+    m_ParalegalEntityName = record.value("ParalegalEntityName").toString();
+    m_WorkAttorneyEntityName = record.value("WorkAttorneyEntityName").toString();
+    m_WithParalegal = record.value("WithParalegal").toBool();
+    m_NeedsExaminerInterview = record.value("NeedsExaminerInterview").toBool();
+    m_ExaminerInterviewScheduled = record.value("ExaminerInterviewScheduled").toBool();
+}
+
 // --- TaskId ---
 Key filingsDashboardEntry::getTaskId() const { return m_TaskId; }
-void filingsDashboardEntry::slotSetTaskId(Key v) { m_TaskId = v; }
+void filingsDashboardEntry::slotSetTaskId(Key v)
+{
+    Nutdb::UpdateField("filingsDashboardComplete", "TaskId", m_TaskId, QString::number(v));
+    m_TaskId = v;
+}
 
 // --- TaskClassName ---
 const QString& filingsDashboardEntry::getTaskClassName() const { return m_TaskClassName; }
-void filingsDashboardEntry::slotSetTaskClassName(const QString& v) { m_TaskClassName = v; }
+void filingsDashboardEntry::slotSetTaskClassName(const QString& v)
+{
+    m_TaskClassName = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "TaskClassName", m_TaskId, v);
+}
 
 // --- AttorneyDocketNumber ---
 const QString& filingsDashboardEntry::getAttorneyDocketNumber() const { return m_AttorneyDocketNumber; }
-void filingsDashboardEntry::slotSetAttorneyDocketNumber(const QString& v) { m_AttorneyDocketNumber = v; }
+void filingsDashboardEntry::slotSetAttorneyDocketNumber(const QString& v)
+{
+    m_AttorneyDocketNumber = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "AttorneyDocketNumber", m_TaskId, v);
+}
 
 // --- TaskName ---
 const QString& filingsDashboardEntry::getTaskName() const { return m_TaskName; }
-void filingsDashboardEntry::slotSetTaskName(const QString& v) { m_TaskName = v; }
+void filingsDashboardEntry::slotSetTaskName(const QString& v)
+{
+    m_TaskName = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "TaskName", m_TaskId, v);
+}
 
 // --- Title ---
 const QString& filingsDashboardEntry::getTitle() const { return m_Title; }
-void filingsDashboardEntry::slotSetTitle(const QString& v) { m_Title = v; }
+void filingsDashboardEntry::slotSetTitle(const QString& v)
+{
+    m_Title = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "Title", m_TaskId, v);
+}
 
 // --- TriggerDate ---
 QDate filingsDashboardEntry::getTriggerDate() const { return m_TriggerDate; }
-void filingsDashboardEntry::slotSetTriggerDate(const QDate& v) { m_TriggerDate = v; }
+void filingsDashboardEntry::slotSetTriggerDate(const QDate& v)
+{
+    m_TriggerDate = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "TriggerDate", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- NextDeadline ---
 QDate filingsDashboardEntry::getNextDeadline() const { return m_NextDeadline; }
-void filingsDashboardEntry::slotSetNextDeadline(const QDate& v) { m_NextDeadline = v; }
+void filingsDashboardEntry::slotSetNextDeadline(const QDate& v)
+{
+    m_NextDeadline = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "NextDeadline", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- SoftDeadline ---
 QDate filingsDashboardEntry::getSoftDeadline() const { return m_SoftDeadline; }
-void filingsDashboardEntry::slotSetSoftDeadline(const QDate& v) { m_SoftDeadline = v; }
+void filingsDashboardEntry::slotSetSoftDeadline(const QDate& v)
+{
+    m_SoftDeadline = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "SoftDeadline", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- HardDeadline ---
 QDate filingsDashboardEntry::getHardDeadline() const { return m_HardDeadline; }
-void filingsDashboardEntry::slotSetHardDeadline(const QDate& v) { m_HardDeadline = v; }
+void filingsDashboardEntry::slotSetHardDeadline(const QDate& v)
+{
+    m_HardDeadline = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "HardDeadline", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- ClientEntityId ---
 Key filingsDashboardEntry::getClientEntityId() const { return m_ClientEntityId; }
-void filingsDashboardEntry::slotSetClientEntityId(Key v) { m_ClientEntityId = v; }
+void filingsDashboardEntry::slotSetClientEntityId(Key v)
+{
+    m_ClientEntityId = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "ClientEntityId", m_TaskId, QString::number(v));
+}
 
 // --- ClientEntityName ---
 const QString& filingsDashboardEntry::getClientEntityName() const { return m_ClientEntityName; }
-void filingsDashboardEntry::slotSetClientEntityName(const QString& v) { m_ClientEntityName = v; }
+void filingsDashboardEntry::slotSetClientEntityName(const QString& v)
+{
+    m_ClientEntityName = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "ClientEntityName", m_TaskId, v);
+}
 
 // --- ParalegalEntityName ---
 const QString& filingsDashboardEntry::getParalegalEntityName() const { return m_ParalegalEntityName; }
-void filingsDashboardEntry::slotSetParalegalEntityName(const QString& v) { m_ParalegalEntityName = v; }
+void filingsDashboardEntry::slotSetParalegalEntityName(const QString& v)
+{
+    m_ParalegalEntityName = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "ParalegalEntityName", m_TaskId, v);
+}
 
 // --- WorkAttorneyEntityName ---
 const QString& filingsDashboardEntry::getWorkAttorneyEntityName() const { return m_WorkAttorneyEntityName; }
-void filingsDashboardEntry::slotSetWorkAttorneyEntityName(const QString& v) { m_WorkAttorneyEntityName = v; }
+void filingsDashboardEntry::slotSetWorkAttorneyEntityName(const QString& v)
+{
+    m_WorkAttorneyEntityName = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "WorkAttorneyEntityName", m_TaskId, v);
+}
 
 // --- WithParalegal ---
 bool filingsDashboardEntry::getWithParalegal() const { return m_WithParalegal; }
-void filingsDashboardEntry::slotSetWithParalegal(bool v) { m_WithParalegal = v; }
+void filingsDashboardEntry::slotSetWithParalegal(bool v)
+{
+    m_WithParalegal = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "WithParalegal", m_TaskId, v ? "1" : "0");
+}
 
 // --- NeedsExaminerInterview ---
 bool filingsDashboardEntry::getNeedsExaminerInterview() const { return m_NeedsExaminerInterview; }
-void filingsDashboardEntry::slotSetNeedsExaminerInterview(bool v) { m_NeedsExaminerInterview = v; }
+void filingsDashboardEntry::slotSetNeedsExaminerInterview(bool v)
+{
+    m_NeedsExaminerInterview = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "NeedsExaminerInterview", m_TaskId, v ? "1" : "0");
+}
 
 // --- ExaminerInterviewScheduled ---
 bool filingsDashboardEntry::getExaminerInterviewScheduled() const { return m_ExaminerInterviewScheduled; }
-void filingsDashboardEntry::slotSetExaminerInterviewScheduled(bool v) { m_ExaminerInterviewScheduled = v; }
+void filingsDashboardEntry::slotSetExaminerInterviewScheduled(bool v)
+{
+    m_ExaminerInterviewScheduled = v;
+    Nutdb::UpdateField("filingsDashboardComplete", "ExaminerInterviewScheduled", m_TaskId, v ? "1" : "0");
+}
 
 } //namespace Nutmeg

--- a/nmbroker/objects/filingsdashboardentry.h
+++ b/nmbroker/objects/filingsdashboardentry.h
@@ -18,6 +18,7 @@
 #include "property.h"
 #include <QString>
 #include <QDate>
+#include <QSqlRecord>
 #include <cstdint>
 
 namespace Nutmeg{
@@ -29,6 +30,7 @@ public:
     filingsDashboardEntry& operator=(const filingsDashboardEntry&) = default;
     filingsDashboardEntry(filingsDashboardEntry&&) noexcept = default;
     filingsDashboardEntry& operator=(filingsDashboardEntry&&) noexcept = default;
+    explicit filingsDashboardEntry(const QSqlRecord &record);
 
     // --- TaskId ---
     Key getTaskId() const;

--- a/nmbroker/objects/responsesdashboardentry.cpp
+++ b/nmbroker/objects/responsesdashboardentry.cpp
@@ -2,6 +2,26 @@
 
 namespace Nutmeg{
 
+responsesDashboardEntry::responsesDashboardEntry(const QSqlRecord &record)
+{
+    m_TaskId = record.value("TaskId").toUInt();
+    m_TaskClassName = record.value("TaskClassName").toString();
+    m_AttorneyDocketNumber = record.value("AttorneyDocketNumber").toString();
+    m_TaskName = record.value("TaskName").toString();
+    m_Title = record.value("Title").toString();
+    m_TriggerDate = record.value("TriggerDate").toDate();
+    m_NextDeadline = record.value("NextDeadline").toDate();
+    m_SoftDeadline = record.value("SoftDeadline").toDate();
+    m_HardDeadline = record.value("HardDeadline").toDate();
+    m_ClientEntityId = record.value("ClientEntityId").toUInt();
+    m_ClientEntityName = record.value("ClientEntityName").toString();
+    m_ParalegalEntityName = record.value("ParalegalEntityName").toString();
+    m_WorkAttorneyEntityName = record.value("WorkAttorneyEntityName").toString();
+    m_WithParalegal = record.value("WithParalegal").toBool();
+    m_NeedsExaminerInterview = record.value("NeedsExaminerInterview").toBool();
+    m_ExaminerInterviewScheduled = record.value("ExaminerInterviewScheduled").toBool();
+}
+
 // --- TaskId ---
 Key responsesDashboardEntry::getTaskId() const { return m_TaskId; }
 void responsesDashboardEntry::slotSetTaskId(Key v) { m_TaskId = v; }

--- a/nmbroker/objects/responsesdashboardentry.cpp
+++ b/nmbroker/objects/responsesdashboardentry.cpp
@@ -1,4 +1,5 @@
 #include "responsesdashboardentry.h"
+#include "dbaccess/nutdb.h"
 
 namespace Nutmeg{
 
@@ -24,66 +25,130 @@ responsesDashboardEntry::responsesDashboardEntry(const QSqlRecord &record)
 
 // --- TaskId ---
 Key responsesDashboardEntry::getTaskId() const { return m_TaskId; }
-void responsesDashboardEntry::slotSetTaskId(Key v) { m_TaskId = v; }
+void responsesDashboardEntry::slotSetTaskId(Key v)
+{
+    Nutdb::UpdateField("responsesDashboardComplete", "TaskId", m_TaskId, QString::number(v));
+    m_TaskId = v;
+}
 
 // --- TaskClassName ---
 const QString& responsesDashboardEntry::getTaskClassName() const { return m_TaskClassName; }
-void responsesDashboardEntry::slotSetTaskClassName(const QString& v) { m_TaskClassName = v; }
+void responsesDashboardEntry::slotSetTaskClassName(const QString& v)
+{
+    m_TaskClassName = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "TaskClassName", m_TaskId, v);
+}
 
 // --- AttorneyDocketNumber ---
 const QString& responsesDashboardEntry::getAttorneyDocketNumber() const { return m_AttorneyDocketNumber; }
-void responsesDashboardEntry::slotSetAttorneyDocketNumber(const QString& v) { m_AttorneyDocketNumber = v; }
+void responsesDashboardEntry::slotSetAttorneyDocketNumber(const QString& v)
+{
+    m_AttorneyDocketNumber = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "AttorneyDocketNumber", m_TaskId, v);
+}
 
 // --- TaskName ---
 const QString& responsesDashboardEntry::getTaskName() const { return m_TaskName; }
-void responsesDashboardEntry::slotSetTaskName(const QString& v) { m_TaskName = v; }
+void responsesDashboardEntry::slotSetTaskName(const QString& v)
+{
+    m_TaskName = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "TaskName", m_TaskId, v);
+}
 
 // --- Title ---
 const QString& responsesDashboardEntry::getTitle() const { return m_Title; }
-void responsesDashboardEntry::slotSetTitle(const QString& v) { m_Title = v; }
+void responsesDashboardEntry::slotSetTitle(const QString& v)
+{
+    m_Title = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "Title", m_TaskId, v);
+}
 
 // --- TriggerDate ---
 QDate responsesDashboardEntry::getTriggerDate() const { return m_TriggerDate; }
-void responsesDashboardEntry::slotSetTriggerDate(const QDate& v) { m_TriggerDate = v; }
+void responsesDashboardEntry::slotSetTriggerDate(const QDate& v)
+{
+    m_TriggerDate = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "TriggerDate", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- NextDeadline ---
 QDate responsesDashboardEntry::getNextDeadline() const { return m_NextDeadline; }
-void responsesDashboardEntry::slotSetNextDeadline(const QDate& v) { m_NextDeadline = v; }
+void responsesDashboardEntry::slotSetNextDeadline(const QDate& v)
+{
+    m_NextDeadline = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "NextDeadline", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- SoftDeadline ---
 QDate responsesDashboardEntry::getSoftDeadline() const { return m_SoftDeadline; }
-void responsesDashboardEntry::slotSetSoftDeadline(const QDate& v) { m_SoftDeadline = v; }
+void responsesDashboardEntry::slotSetSoftDeadline(const QDate& v)
+{
+    m_SoftDeadline = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "SoftDeadline", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- HardDeadline ---
 QDate responsesDashboardEntry::getHardDeadline() const { return m_HardDeadline; }
-void responsesDashboardEntry::slotSetHardDeadline(const QDate& v) { m_HardDeadline = v; }
+void responsesDashboardEntry::slotSetHardDeadline(const QDate& v)
+{
+    m_HardDeadline = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "HardDeadline", m_TaskId, v.toString("yyyy-MM-dd"));
+}
 
 // --- client_EntityId ---
 Key responsesDashboardEntry::getClientEntityId() const { return m_ClientEntityId; }
-void responsesDashboardEntry::slotSetClientEntityId(Key v) { m_ClientEntityId = v; }
+void responsesDashboardEntry::slotSetClientEntityId(Key v)
+{
+    m_ClientEntityId = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "ClientEntityId", m_TaskId, QString::number(v));
+}
 
 // --- client_EntityName ---
 const QString& responsesDashboardEntry::getClientEntityName() const { return m_ClientEntityName; }
-void responsesDashboardEntry::slotSetClientEntityName(const QString& v) { m_ClientEntityName = v; }
+void responsesDashboardEntry::slotSetClientEntityName(const QString& v)
+{
+    m_ClientEntityName = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "ClientEntityName", m_TaskId, v);
+}
 
 // --- paralegal_EntityName ---
 const QString& responsesDashboardEntry::getParalegalEntityName() const { return m_ParalegalEntityName; }
-void responsesDashboardEntry::slotSetParalegalEntityName(const QString& v) { m_ParalegalEntityName = v; }
+void responsesDashboardEntry::slotSetParalegalEntityName(const QString& v)
+{
+    m_ParalegalEntityName = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "ParalegalEntityName", m_TaskId, v);
+}
 
 // --- workAttorney_EntityName ---
 const QString& responsesDashboardEntry::getWorkAttorneyEntityName() const { return m_WorkAttorneyEntityName; }
-void responsesDashboardEntry::slotSetWorkAttorneyEntityName(const QString& v) { m_WorkAttorneyEntityName = v; }
+void responsesDashboardEntry::slotSetWorkAttorneyEntityName(const QString& v)
+{
+    m_WorkAttorneyEntityName = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "WorkAttorneyEntityName", m_TaskId, v);
+}
 
 // --- WithParalegal ---
 bool responsesDashboardEntry::getWithParalegal() const { return m_WithParalegal; }
-void responsesDashboardEntry::slotSetWithParalegal(bool v) { m_WithParalegal = v; }
+void responsesDashboardEntry::slotSetWithParalegal(bool v)
+{
+    m_WithParalegal = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "WithParalegal", m_TaskId, v ? "1" : "0");
+}
 
 // --- NeedsExaminerInterview ---
 bool responsesDashboardEntry::getNeedsExaminerInterview() const { return m_NeedsExaminerInterview; }
-void responsesDashboardEntry::slotSetNeedsExaminerInterview(bool v) { m_NeedsExaminerInterview = v; }
+void responsesDashboardEntry::slotSetNeedsExaminerInterview(bool v)
+{
+    m_NeedsExaminerInterview = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "NeedsExaminerInterview", m_TaskId, v ? "1" : "0");
+}
 
 // --- ExaminerInterviewScheduled ---
 bool responsesDashboardEntry::getExaminerInterviewScheduled() const { return m_ExaminerInterviewScheduled; }
-void responsesDashboardEntry::slotSetExaminerInterviewScheduled(bool v) { m_ExaminerInterviewScheduled = v; }
+void responsesDashboardEntry::slotSetExaminerInterviewScheduled(bool v)
+{
+    m_ExaminerInterviewScheduled = v;
+    Nutdb::UpdateField("responsesDashboardComplete", "ExaminerInterviewScheduled", m_TaskId, v ? "1" : "0");
+}
 
 } //namespace Nutmeg

--- a/nmbroker/objects/responsesdashboardentry.h
+++ b/nmbroker/objects/responsesdashboardentry.h
@@ -18,6 +18,7 @@
 #include "property.h"
 #include <QString>
 #include <QDate>
+#include <QSqlRecord>
 #include <cstdint>
 
 namespace Nutmeg{
@@ -30,6 +31,7 @@ public:
     responsesDashboardEntry& operator=(const responsesDashboardEntry&) = default;
     responsesDashboardEntry(responsesDashboardEntry&&) noexcept = default;
     responsesDashboardEntry& operator=(responsesDashboardEntry&&) noexcept = default;
+    explicit responsesDashboardEntry(const QSqlRecord &record);
 
     // --- TaskId ---
     Key getTaskId() const;

--- a/nmgui/mainwindow.cpp
+++ b/nmgui/mainwindow.cpp
@@ -52,7 +52,7 @@ void MainWindow::Refresh()
 
         // Make sure models have the latest data
         gViewFilingsIncompleteModel->select();
-        gViewResponsesIncompleteModel->select();
+        gResponsesDashboardComplete->select();
         gViewUpcomingAppointmentsModel->select();
 
         delete dash;

--- a/nmgui/nmgui.pro
+++ b/nmgui/nmgui.pro
@@ -23,6 +23,7 @@ SOURCES += \
     ../nmbroker/dbaccess/exception.cpp \
     ../nmbroker/dbaccess/flagclassmodel.cpp \
     ../nmbroker/dbaccess/models.cpp \
+    ../nmbroker/dbaccess/responsesdashboardcomplete.cpp \
     ../nmbroker/dbaccess/objectmodel.cpp \
     ../nmbroker/dbaccess/objecttypemodel.cpp \
     ../nmbroker/dbaccess/tagmodel.cpp \
@@ -123,7 +124,6 @@ SOURCES += \
     ../nmbroker/dbaccess/viewpatentexaminersmodel.cpp \
     ../nmbroker/dbaccess/viewpatenttasktypesmodel.cpp \
     ../nmbroker/dbaccess/viewpeoplemodel.cpp \
-    ../nmbroker/dbaccess/viewresponsesincompletemodel.cpp \
     ../nmbroker/dbaccess/viewtaskclassmodel.cpp \
     ../nmbroker/dbaccess/viewtasktypesmodel.cpp \
     ../nmbroker/dbaccess/viewtrademarktasktypesmodel.cpp \
@@ -204,6 +204,7 @@ HEADERS += \
     ../nmbroker/dbaccess/exception.h \
     ../nmbroker/dbaccess/flagclassmodel.h \
     ../nmbroker/dbaccess/models.h \
+    ../nmbroker/dbaccess/responsesdashboardcomplete.h \
     ../nmbroker/dbaccess/objectmodel.h \
     ../nmbroker/dbaccess/objecttypemodel.h \
     ../nmbroker/dbaccess/record.h \
@@ -307,7 +308,6 @@ HEADERS += \
     ../nmbroker/dbaccess/viewparalegalsmodel.h \
     ../nmbroker/dbaccess/viewpatenttasktypesmodel.h \
     ../nmbroker/dbaccess/viewpeoplemodel.h \
-    ../nmbroker/dbaccess/viewresponsesincompletemodel.h \
     ../nmbroker/dbaccess/viewtrademarktasktypesmodel.h \
     ../nmbroker/dbaccess/viewworkattorneysmodel.h \
     ../nmbroker/nutmeg.h \

--- a/nmgui/panels/responsesdashboard.cpp
+++ b/nmgui/panels/responsesdashboard.cpp
@@ -45,23 +45,7 @@ void ResponsesDashboard::SetupResponses()
     for (auto i = 0; i < rows; i++)
     {
         QSqlRecord rec = gResponsesDashboardComplete->record(i);
-        responsesDashboardEntry entry;
-        entry.slotSetTaskId(rec.field("TaskId").value().toUInt());
-        entry.slotSetTaskClassName(rec.field("TaskClassName").value().toString());
-        entry.slotSetAttorneyDocketNumber(rec.field("AttorneyDocketNumber").value().toString());
-        entry.slotSetTaskName(rec.field("TaskName").value().toString());
-        entry.slotSetTitle(rec.field("Title").value().toString());
-        entry.slotSetTriggerDate(rec.field("TriggerDate").value().toDate());
-        entry.slotSetNextDeadline(rec.field("NextDeadline").value().toDate());
-        entry.slotSetSoftDeadline(rec.field("SoftDeadline").value().toDate());
-        entry.slotSetHardDeadline(rec.field("HardDeadline").value().toDate());
-        entry.slotSetClientEntityId(rec.field("ClientEntityId").value().toUInt());
-        entry.slotSetClientEntityName(rec.field("ClientEntityName").value().toString());
-        entry.slotSetParalegalEntityName(rec.field("ParalegalEntityName").value().toString());
-        entry.slotSetWorkAttorneyEntityName(rec.field("WorkAttorneyEntityName").value().toString());
-        entry.slotSetWithParalegal(rec.field("WithParalegal").value().toBool());
-        entry.slotSetNeedsExaminerInterview(rec.field("NeedsExaminerInterview").value().toBool());
-        entry.slotSetExaminerInterviewScheduled(rec.field("ExaminerInterviewScheduled").value().toBool());
+        responsesDashboardEntry entry(rec);
         ResponseDashPanel *rpanel = new ResponseDashPanel(entry, responsesContainer);
         responseDashPanels.append(rpanel);
         responsesLayout->addWidget(rpanel);

--- a/nmgui/panels/responsesdashboard.cpp
+++ b/nmgui/panels/responsesdashboard.cpp
@@ -1,6 +1,7 @@
 #include "responsesdashboard.h"
 #include "windows/newresponsedialog.h"
 #include "objects/responsesdashboardentry.h"
+#include "dbaccess/models.h"
 
 namespace Nutmeg {
 
@@ -37,13 +38,13 @@ void ResponsesDashboard::SetupResponses()
     QVBoxLayout *responsesLayout = new QVBoxLayout(responsesContainer);
 
     // Create the global responses model if it hasn't already been loaded
-    gViewResponsesIncompleteModel = std::make_unique<viewResponsesIncompleteModel>();
+    gResponsesDashboardComplete = std::make_unique<ResponsesDashboardComplete>();
 
     // Populate the responses container with ResponsePanels
-    auto rows = gViewResponsesIncompleteModel->rowCount();
+    auto rows = gResponsesDashboardComplete->rowCount();
     for (auto i = 0; i < rows; i++)
     {
-        QSqlRecord rec = gViewResponsesIncompleteModel->record(i);
+        QSqlRecord rec = gResponsesDashboardComplete->record(i);
         responsesDashboardEntry entry;
         entry.slotSetTaskId(rec.field("TaskId").value().toUInt());
         entry.slotSetTaskClassName(rec.field("TaskClassName").value().toString());


### PR DESCRIPTION
## Summary
- add `ResponsesDashboardComplete` TableModel for `responsesDashboardComplete` view
- register new model in global models registry
- switch dashboard to use `ResponsesDashboardComplete` and remove legacy `viewResponsesIncompleteModel`

## Testing
- `qmake nmgui/nmgui.pro` *(fails: command not found)*
- `make -C nmgui` *(fails: qmake missing)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5080afd708324a708be5de95df5f5